### PR TITLE
AMP-23804 AMP Timor Staging - The Indicator layers from map configuration are not working

### DIFF
--- a/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/data/collections/indicator-collection.js
+++ b/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/data/collections/indicator-collection.js
@@ -40,7 +40,7 @@ module.exports = Backbone.Collection
     var deferred = $.Deferred();
     this.load().then(function() {
       self.url = '/rest/gis/indicators';
-      self.fetch().then(function() {
+      self.fetch({remove: false}).then(function() {
         deferred.resolve();
       });
     });


### PR DESCRIPTION
AMP-23804 AMP Timor Staging - The Indicator layers from map configuration are not working - reintroduce remove:false option to fetch in indicator collection
