### PR TITLE
AMP-22603 Saiku doubles the Donor Group entries in Filters 

### DIFF
--- a/amp/TEMPLATE/ampTemplate/saikuui_nireports/js/saiku/plugins/AMPFilters/FilterUtils.js
+++ b/amp/TEMPLATE/ampTemplate/saikuui_nireports/js/saiku/plugins/AMPFilters/FilterUtils.js
@@ -29,7 +29,7 @@ FilterUtils.extractFilters = function(content) {
 			}
 			if (element.value !== null) {
 				content.push(self.parseValue(element, element.value));
-			} else if (element.valueToName !== null) {
+			} else if (element.valueToName !== null && content.length === 0 ) {
 				// This should be .models but the way the endpoint returns
 				// the data breaks backbone.
 				_.each(element.valueToName, function(item_, i) {


### PR DESCRIPTION
AMP-22603 Saiku doubles the Donor Group entries in Filters 
- add check to prevent unnecessary execution of element.valueToName iteration
