### PR TITLE
AMP-23006: Update jersey library version to 1.19 (Java8 compatible)

### DIFF
--- a/amp/pom.xml
+++ b/amp/pom.xml
@@ -13,7 +13,7 @@
         <springVersion>3.0.7.RELEASE</springVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <buildVersion>2.12-SNAPSHOT</buildVersion>
-        <jersey.version>1.18</jersey.version>
+        <jersey.version>1.19</jersey.version>
         <saiku.version>3.0-RC2</saiku.version>
         <saiku3.version>3.0-RC2-DG</saiku3.version>
         <apidocs>false</apidocs>


### PR DESCRIPTION
Updated jersey library version to 1.19 in order to be compatible with Java 8
