### PR TITLE
AMP-23156: add 'ignore Expenditure Class' logic to Report Wizard

### DIFF
--- a/amp/WEB-INF/src/org/digijava/module/aim/action/reportwizard/ReportWizardAction.java
+++ b/amp/WEB-INF/src/org/digijava/module/aim/action/reportwizard/ReportWizardAction.java
@@ -826,11 +826,15 @@ public class ReportWizardAction extends MultiAction {
         for(AmpFieldsVisibility field:ampAllFields)
             ampAllFieldsByName.put(field.getName(), field);
 
-        //int iterations1 = 0, iterations2 = 0;
         for(AmpColumns ampColumn:allAmpColumns)
         {
+            if (FeaturesUtil.columnIgnoredInReportWizard(ampColumn.getColumnName()))
+            	continue;
+
+        	
             AmpFieldsVisibility ampFieldVisibility = ampAllFieldsByName.get(ampColumn.getColumnName());
 
+            
             if(ampFieldVisibility == null)
                 continue;
 
@@ -868,7 +872,6 @@ public class ReportWizardAction extends MultiAction {
                 if (!aco.getColumnName().equalsIgnoreCase(ArConstants.PLEDGES_COLUMNS) && !aco.getColumnName().equalsIgnoreCase(ArConstants.PLEDGES_CONTACTS_1)
                         && !aco.getColumnName().equalsIgnoreCase(ArConstants.PLEDGES_CONTACTS_2)){
                     ampThemesOrdered.add(aco);
-                    //System.out.println("	----------------ADDED!");
                 }
             }
         }

--- a/amp/WEB-INF/src/org/digijava/module/aim/util/FeaturesUtil.java
+++ b/amp/WEB-INF/src/org/digijava/module/aim/util/FeaturesUtil.java
@@ -1,6 +1,7 @@
 package org.digijava.module.aim.util;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
@@ -17,6 +18,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpSession;
 
 import org.apache.log4j.Logger;
+import org.dgfoundation.amp.ar.ColumnConstants;
 import org.dgfoundation.amp.newreports.AmountsUnits;
 import org.dgfoundation.amp.visibility.AmpObjectVisibility;
 import org.dgfoundation.amp.visibility.AmpTreeVisibility;
@@ -66,6 +68,8 @@ public class FeaturesUtil {
 	public static String errorLog = "";
 	
 	public final static String AMP_TREE_VISIBILITY_ATTR = "ampTreeVisibility";
+
+	private static Set<String> columnsIgnoredInReportWizard = new HashSet<>(Arrays.asList(ColumnConstants.EXPENDITURE_CLASS));
 	
 	public static void logGlobalSettingsCache() {
 		String log = "";
@@ -76,10 +80,14 @@ public class FeaturesUtil {
 		logger.info("GlobalSettingsCache is -> " + log);
 	}
 
+	
 	public static synchronized Map<String, AmpGlobalSettings> getGlobalSettingsCache() {
 		return globalSettingsCache;
 	}
-
+	
+	public static boolean columnIgnoredInReportWizard(String columnName) {
+		return columnsIgnoredInReportWizard.contains(columnName);
+	}
 	public static synchronized void buildGlobalSettingsCache(List<AmpGlobalSettings> globalSettings) {
 		globalSettingsCache = new HashMap<String, AmpGlobalSettings>();
 		for (AmpGlobalSettings sett : globalSettings) {


### PR DESCRIPTION
Report Wizard doesn't use ColumnsVisibility, instead digging through 
AmpTreeVisibility directly. Therefore, logic about which columns 
should exist as columns (since there are filters bound to them), but 
not be visible in the Report Generator, is to be created in 
FeaturesUtil.
