### PR TITLE
AMP-24189 Gap analysis legend showing wrong label

### DIFF
--- a/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/map/legend/legend-item-indicator-join.html
+++ b/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/map/legend/legend-item-indicator-join.html
@@ -8,12 +8,11 @@
     <% colourBuckets.each(function(bucket) { %>
       <% if(bucket.get('value') && !_.isNaN(bucket.get('value')[0]) && _.isFinite(bucket.get('value')[0])) { %>
       <div>
-        <span style="background: <%= bucket.hex() %> !important" class="color-block legend-sample"></span>
-        
-        <% 
-        var ratioOtherIndicator = self.app.data.indicatorTypes.findWhere({'orig-name': Constants.INDICATOR_TYPE_RATIO_OTHER});
-        var percentIndicator = self.app.data.indicatorTypes.findWhere({'orig-name': Constants.INDICATOR_TYPE_RATIO_PERCENTAGE});        
-        if((percentIndicator && percentIndicator.get('id') === model.get('indicatorTypeId')) || (ratioOtherIndicator && ratioOtherIndicator.get('id') === model.get('indicatorTypeId'))) { %>        
+        <span style="background: <%= bucket.hex() %> !important" class="color-block legend-sample"></span>        
+        <%          
+          var ratioOtherIndicator = self.app.data.indicatorTypes.findWhere({'orig-name': Constants.INDICATOR_TYPE_RATIO_OTHER});
+          var percentIndicator = self.app.data.indicatorTypes.findWhere({'orig-name': Constants.INDICATOR_TYPE_RATIO_PERCENTAGE});        
+          if(model.get('gapAnalysis') === false && ((percentIndicator && percentIndicator.get('id') === model.get('indicatorTypeId')) || (ratioOtherIndicator && ratioOtherIndicator.get('id') === model.get('indicatorTypeId')))) { %>        
           <%= util.formatPercentage()(bucket.get('value')[0]) %>&mdash;<%= util.formatPercentage()(bucket.get('value')[1]) %>
         <% } else { %>
           <%= util.formatKMB()(bucket.get('value')[0]) %>&mdash;<%= util.formatKMB()(bucket.get('value')[1]) %> <%= unit %>


### PR DESCRIPTION
AMP-24189 Gap analysis legend showing wrong label

Use 'unit' field data provided by BE for Gap Analysis label - this should happen regardless of the type of layer. The problem was for percentage layers Gap Analysis was displaying % instead of the 'unit' data provided by the BE
