### PR TITLE
AMP-23648: Fixed the visibility of the export formats in settings

### DIFF
--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/settings/SettingsUtils.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/settings/SettingsUtils.java
@@ -441,7 +441,7 @@ public class SettingsUtils {
 				"hide-editable-export-formats-public-view",
 				GlobalSettingsConstants.HIDE_EDITABLE_EXPORT_FORMATS_PUBLIC_VIEW,
 				new SettingOptions.Option(
-						String.valueOf(!FeaturesUtil.isVisibleFeature("Show Editable Export Formats")))));
+						String.valueOf(!FeaturesUtil.isVisibleModule("Show Editable Export Formats")))));
 		settings.add(new SettingOptions(
 				"download-map-selector",
 				GisConstants.DOWNLOAD_MAP_SELECTOR,


### PR DESCRIPTION
A quick fix since "Show Editable Export Formats" is a module (was a feature)
