### PR TITLE
AMP-16872: Fix amp-deployer SSH key file permissions.

### DIFF
--- a/amp-deployer/Vagrantfile
+++ b/amp-deployer/Vagrantfile
@@ -46,8 +46,8 @@ else
   raise 'Can not find the AnsibleMain.local.yml or AnsibleMain.yml.'
 end
 
-# Vagrant v1.8.4 is required for ansible_local provisioning to work properly.
-Vagrant.require_version ">= 1.8.4"
+# Vagrant v1.8.6 is required for SSH connection to work properly.
+Vagrant.require_version ">= 1.8.6"
 
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version.


### PR DESCRIPTION
Vagrant version 1.8.6 or newer is required in order to avoid this issue: mitchellh/vagrant#7753
