### PR TITLE
AMP-23946: The clean process shouldn't fail if the WEB-INF/lib folder does note exist.

### DIFF
--- a/amp/build.xml
+++ b/amp/build.xml
@@ -333,7 +333,7 @@
       <delete dir="${doc.path}"/>
       <delete dir="${gen-src}"/>
       <delete dir="${metainf}"/>    	
-  	  <delete includeemptydirs="true">
+  	  <delete includeemptydirs="true" failonerror="false">
   	    <fileset dir="${webinf}/lib" includes="**/*"/>
   	  </delete>
     </target>


### PR DESCRIPTION
AMP-23946: The clean process shouldn't fail if the WEB-INF/lib folder
does note exist.

(cherry picked from commit 60c31ff)
