### PR TITLE
AMP-24358: Setting definitions

### DIFF
--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/errors/ApiError.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/errors/ApiError.java
@@ -15,6 +15,7 @@ import org.digijava.kernel.ampapi.endpoints.gis.GisEndPoints;
 import org.digijava.kernel.ampapi.endpoints.indicator.IndicatorEndPoints;
 import org.digijava.kernel.ampapi.endpoints.reports.Reports;
 import org.digijava.kernel.ampapi.endpoints.security.Security;
+import org.digijava.kernel.ampapi.endpoints.settings.SettingsDefinitionsEndpoint;
 import org.digijava.kernel.ampapi.endpoints.util.JsonBean;
 import org.digijava.kernel.translator.TranslatorWorker;
 
@@ -45,6 +46,7 @@ public class ApiError {
         put(EndPoints.class.getName(), 5);
         put(IndicatorEndPoints.class.getName(), 6);
         put(GisEndPoints.class.getName(), 7);
+        put(SettingsDefinitionsEndpoint.class.getName(), 8);
 	}};
 	
 	/**

--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/reports/ReportErrors.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/reports/ReportErrors.java
@@ -20,4 +20,5 @@ public class ReportErrors {
     public static final ApiErrorMessage REPORT_TYPE_INVALID = new ApiErrorMessage(4, "Invalid report type: ");
     public static final ApiErrorMessage REPORT_TYPE_REQUIRED = new ApiErrorMessage(5, "Project type is required");
     public static final ApiErrorMessage ACTIVITY_TYPE_LIST_INVALID = new ApiErrorMessage(6, "Invalid list of activity types: ");
+    public static final ApiErrorMessage REPORT_NOT_FOUND = new ApiErrorMessage(7, "Report not found");
 }

--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/reports/Reports.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/reports/Reports.java
@@ -1,5 +1,7 @@
 package org.digijava.kernel.ampapi.endpoints.reports;
 
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -49,6 +51,7 @@ import org.dgfoundation.amp.visibility.data.ColumnsVisibility;
 import org.dgfoundation.amp.visibility.data.MeasuresVisibility;
 import org.digijava.kernel.ampapi.endpoints.common.EPConstants;
 import org.digijava.kernel.ampapi.endpoints.common.EndpointUtils;
+import org.digijava.kernel.ampapi.endpoints.errors.ApiErrorResponse;
 import org.digijava.kernel.ampapi.endpoints.errors.ErrorReportingEndpoint;
 import org.digijava.kernel.ampapi.endpoints.settings.SettingsConstants;
 import org.digijava.kernel.ampapi.endpoints.settings.SettingsUtils;
@@ -106,7 +109,11 @@ public class Reports implements ErrorReportingEndpoint {
 	@Path("/report/{report_id}")
 	@Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
 	public final JSONResult getReport(@PathParam("report_id") Long reportId) {
-		JSONResult report = getReport(DbUtil.getAmpReport(reportId));
+		AmpReports ampReport = DbUtil.getAmpReport(reportId);
+		if (ampReport == null) {
+			ApiErrorResponse.reportError(BAD_REQUEST, ReportErrors.REPORT_NOT_FOUND);
+		}
+		JSONResult report = getReport(ampReport);
 		report.getReportMetadata().setReportType(SAVED);
 		report.getReportMetadata().setReportIdentifier(reportId.toString());
 		return report;

--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/settings/SettingsDefinitionsEndpoint.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/settings/SettingsDefinitionsEndpoint.java
@@ -1,5 +1,6 @@
 package org.digijava.kernel.ampapi.endpoints.settings;
 
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.digijava.kernel.ampapi.endpoints.settings.SettingsUtils.getReportYearRangeField;
 import static org.digijava.kernel.ampapi.endpoints.settings.SettingsUtils.getCurrencyField;
 import static org.digijava.kernel.ampapi.endpoints.settings.SettingsUtils.getCalendarField;
@@ -18,6 +19,8 @@ import javax.ws.rs.core.MediaType;
 
 import org.dgfoundation.amp.newreports.ReportSpecification;
 import org.dgfoundation.amp.reports.mondrian.converters.AmpReportsToReportSpecification;
+import org.digijava.kernel.ampapi.endpoints.errors.ApiErrorResponse;
+import org.digijava.kernel.ampapi.endpoints.errors.ErrorReportingEndpoint;
 import org.digijava.module.aim.dbentity.AmpReports;
 import org.digijava.module.aim.util.DbUtil;
 
@@ -28,7 +31,7 @@ import org.digijava.module.aim.util.DbUtil;
  * @author Octavian Ciubotaru
  */
 @Path("settings-definitions")
-public class SettingsDefinitionsEndpoint {
+public class SettingsDefinitionsEndpoint implements ErrorReportingEndpoint {
 
     /**
      * Returns setting definitions for dashboards.
@@ -96,11 +99,20 @@ public class SettingsDefinitionsEndpoint {
     @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
     public final List<SettingField> getSettingDefinitionsForReport(@PathParam("report_id") Long reportId) {
         AmpReports ampReport = DbUtil.getAmpReport(reportId);
+        if (ampReport == null) {
+            ApiErrorResponse.reportError(BAD_REQUEST, SettingsDefinitionsErrors.REPORT_NOT_FOUND);
+        }
+
         ReportSpecification spec = AmpReportsToReportSpecification.convert(ampReport);
         return Arrays.asList(
                 getCurrencyField(),
                 getCalendarField(),
                 getCalendarCurrenciesField(),
                 getReportYearRangeField(spec));
+    }
+
+    @Override
+    public Class getErrorsClass() {
+        return SettingsDefinitionsErrors.class;
     }
 }

--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/settings/SettingsDefinitionsErrors.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/settings/SettingsDefinitionsErrors.java
@@ -1,0 +1,11 @@
+package org.digijava.kernel.ampapi.endpoints.settings;
+
+import org.digijava.kernel.ampapi.endpoints.errors.ApiErrorMessage;
+
+/**
+ * @author Octavian Ciubotaru
+ */
+public class SettingsDefinitionsErrors {
+
+    public static final ApiErrorMessage REPORT_NOT_FOUND = new ApiErrorMessage(1, "Report not found");
+}

--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/settings/SettingsUtils.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/settings/SettingsUtils.java
@@ -188,7 +188,7 @@ public class SettingsUtils {
 	private static Settings.YearRange getReportYearRange(ReportSpecification spec) {
 		Settings.YearRange yearRange = null;
 
-		if (spec.getSettings() != null && spec.getSettings().getYearRangeFilter() != null) {
+		if (spec != null && spec.getSettings() != null && spec.getSettings().getYearRangeFilter() != null) {
 			yearRange = new Settings.YearRange();
 			yearRange.setFrom(getReportYear(spec.getSettings().getYearRangeFilter().min));
 			yearRange.setTo(getReportYear(spec.getSettings().getYearRangeFilter().max));


### PR DESCRIPTION
AMP-24358
- Fixed NPE
- Return appropriate error when an invalid report id was passed to /settings-definitions/report/{id} and /data/report/{id}