### PR TITLE
AMP-23753: Changed the way we send query paramters through restclient…

### DIFF
--- a/amp-cms/sites/all/modules/custom/ampapi/includes/ampAPIRestClient.inc
+++ b/amp-cms/sites/all/modules/custom/ampapi/includes/ampAPIRestClient.inc
@@ -125,7 +125,7 @@ class ampAPIRestClient {
     }
 
     if (!empty($langcode) && $langcode != LANGUAGE_NONE) {
-      $options['parameters']['language'] = $langcode;
+      $options['query']['language'] = $langcode;
     }
 
     switch ($request_type) {


### PR DESCRIPTION
Because the restclient.module does something weird with the parameters, never actually appending them, we can send those parameters through the 'query' option - in that case, they get appended.
Tested locally - worked well and activity statuses queried were translated as expected.