### PR TITLE
AMP-24582 Ratio by population does not convert decimals to %

### DIFF
--- a/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/map/legend/legend-item-indicator-join.js
+++ b/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/map/legend/legend-item-indicator-join.js
@@ -26,7 +26,7 @@ module.exports = Backbone.View.extend({
 	  var ratioOtherIndicator = this.app.data.indicatorTypes.findWhere({'orig-name': Constants.INDICATOR_TYPE_RATIO_OTHER});
 	  var percentIndicator = this.app.data.indicatorTypes.findWhere({'orig-name': Constants.INDICATOR_TYPE_RATIO_PERCENTAGE});
 	  
-	  if(model.get('gapAnalysis') === false && ((percentIndicator && percentIndicator.get('id') === model.get('indicatorTypeId')) || (ratioOtherIndicator && ratioOtherIndicator.get('id') === model.get('indicatorTypeId')))) {       
+	  if(model.get('gapAnalysis') !== true && ((percentIndicator && percentIndicator.get('id') === model.get('indicatorTypeId')) || (ratioOtherIndicator && ratioOtherIndicator.get('id') === model.get('indicatorTypeId')))) {       
 		  values.min = chartUtils.formatPercentage()(bucket.get('value')[0]);
 		  values.max = chartUtils.formatPercentage()(bucket.get('value')[1]);
 		  values.isPercent = true;

--- a/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/map/views/indicator-layers-view.js
+++ b/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/map/views/indicator-layers-view.js
@@ -176,7 +176,7 @@ module.exports = Backbone.View.extend({
         var value;
         var percentIndicator = self.app.data.indicatorTypes.findWhere({'orig-name': Constants.INDICATOR_TYPE_RATIO_PERCENTAGE});
         var ratioOtherIndicator = self.app.data.indicatorTypes.findWhere({'orig-name': Constants.INDICATOR_TYPE_RATIO_OTHER});
-        if(layerModel.get('gapAnalysis') === false && ((percentIndicator && percentIndicator.get('id') === layerModel.get('indicatorTypeId')) || (ratioOtherIndicator && ratioOtherIndicator.get('id') === layerModel.get('indicatorTypeId')))){
+        if(layerModel.get('gapAnalysis') !== true && ((percentIndicator && percentIndicator.get('id') === layerModel.get('indicatorTypeId')) || (ratioOtherIndicator && ratioOtherIndicator.get('id') === layerModel.get('indicatorTypeId')))){
         	value = ampFormatter.format(feature.properties.value * 100);
         }else{
         	value = ampFormatter.format(feature.properties.value)


### PR DESCRIPTION
AMP-24582 Ratio by population does not convert decimals to %

Modify the condition model.get('gapAnalysis') === false which does not
work correctly when model.get('gapAnalysis') is undefined