### PR TITLE
AMP-24563 Statistical layers not included when map shared

### DIFF
--- a/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/sidebar/layers/views/indicator-layers-view.js
+++ b/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/sidebar/layers/views/indicator-layers-view.js
@@ -70,7 +70,7 @@ module.exports = Backbone.View.extend({
     		auxId = id.id;
     	}
     	if (auxId) {
-            var selectedModel = self.collection.findWhere({id: "J" + auxId});
+            var selectedModel = self.collection.findWhere({id: auxId});
         	if (selectedModel) {				
 				// Refresh the Gap Analysis area first because we need the parameter for the indicator EP.
 				if (selectedModel.get('canDoGapAnalysis') === true) {


### PR DESCRIPTION
AMP-24563 Statistical layers not included when map shared
Remove 'J' prefix added to findWhere in indicator-layer-view. The layer id
is saved with the prefix so no need to add it.