### PR TITLE
AMP-24640 Statistical Layer assigns value of 0

### DIFF
--- a/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/data/models/indicator-join-model.js
+++ b/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/data/models/indicator-join-model.js
@@ -206,7 +206,11 @@ loadAll: function(options) {
    },
   _joinDataWithBoundaries: function(boundaryGeoJSON) {
     var self = this;
-    var indexedValues = _.indexBy(this.get('values'), 'geoId');
+    var values = _.map(this.get('values'), function(value){
+    	value.geoId = value.geoId ? $.trim(value.geoId) : value.geoId; 
+    	return value;
+    });
+    var indexedValues = _.indexBy(values, 'geoId');
     if(indexedValues["null"]) {
         indexedValues[0] = indexedValues["null"]; //hack for some countries the geoId is null.
     }
@@ -218,7 +222,8 @@ loadAll: function(options) {
         // replace boundary properties with {value: value}
         // TODO... keep the existing properties and just add value?
         // replacing for now, to save weight
-        feature.id = feature.properties[admKey + '_CODE'];
+    	var admCode = feature.properties[admKey + '_CODE'];
+    	feature.id = admCode ? $.trim(admCode) : admCode;
         feature.properties.name = feature.properties[admKey + '_NAME'] || '';
 
         if (!indexedValues[feature.id]) {


### PR DESCRIPTION
AMP-24640 Statistical Layer assigns value of 0
Trim geoId and ADM Code - white spaces cause mismatch for some ADMs