### PR TITLE
AMP-24802: Ignore pg_restore errors while starting dockerized AMP

### DIFF
--- a/amp/amp-postgres/Dockerfile
+++ b/amp/amp-postgres/Dockerfile
@@ -1,0 +1,15 @@
+FROM postgres:9.4
+MAINTAINER Octavian Ciubotaru <ociubotaru@developmentgateway.org>
+
+ENV GIS_MAJOR 2.3
+ENV GIS_VERSION 2.3.0+dfsg-2.pgdg80+1
+
+ENV POSTGRES_PASSWORD postgres
+
+RUN apt-get update \
+        && apt-get install -y --no-install-recommends \
+                postgresql-$PG_MAJOR-postgis-$GIS_MAJOR=$GIS_VERSION \
+                postgresql-$PG_MAJOR-postgis-$GIS_MAJOR-scripts=$GIS_VERSION \
+        && rm -rf /var/lib/apt/lists/*
+
+COPY restore-amp-db.sh /docker-entrypoint-initdb.d/

--- a/amp/amp-postgres/restore-amp-db.sh
+++ b/amp/amp-postgres/restore-amp-db.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+psql -U postgres -c "CREATE ROLE amp ENCRYPTED PASSWORD 'md550b803cf678bf4a8b26a93f679fcdd45' SUPERUSER CREATEDB CREATEROLE INHERIT LOGIN;"
+createdb -U amp amp
+# using ! before pg_restore to ignore returned error status
+# reason: sometimes it fails while restoring postgres-gis tables, this is not critical problem so we will ignore it
+! pg_restore -U amp -O -d amp /backups/amp_database.pgsql
+psql -U amp -c "UPDATE dg_site_domain SET site_domain='$AMP_SITE_DOMAIN';"


### PR DESCRIPTION
AMP-24802: Ignore pg_restore errors while starting dockerized AMP