### PR TITLE
AMP-25275 NiReports are not loading under IE11

### DIFF
--- a/amp/TEMPLATE/ampTemplate/script/common/CommonFilterUtils.js
+++ b/amp/TEMPLATE/ampTemplate/script/common/CommonFilterUtils.js
@@ -208,8 +208,12 @@ CommonFilterUtils.calculateMD5FromParameters = function (model, id, lang, timest
 			for (var property in model.queryModel.filters) {
 				// To avoid problems with prototype´s properties.
 				if (model.queryModel.filters.hasOwnProperty(property)) {
-					// Sort ID's.
-					filters[property] = _.sortBy(model.queryModel.filters[property], function(item) {return item;});
+					// Sort ID's.					
+					if(_.isArray(model.queryModel.filters[property])){
+						filters[property] = _.sortBy(model.queryModel.filters[property], function(item) {return item;});
+					}else{
+						filters[property] = model.queryModel.filters[property];
+					}					
 				}
 			}
 			// Now sort the properties of the object so stringify will return the same string.


### PR DESCRIPTION
AMP-25275 NiReports are not loading under IE11
Add check in CommonFilterUtils.calculateMD5FromParameters to prevent calling of _.sortBy with non-arrays.