### PR TITLE
AMP-25125 Hide Computed Year filter in GIS and Dashboard

### DIFF
--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/common/FiltersEndpoint.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/common/FiltersEndpoint.java
@@ -913,7 +913,7 @@ public class FiltersEndpoint {
     @Path("/computed-year")
     @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
     @ApiMethod(ui = true, id = FiltersConstants.COMPUTED_YEAR, name = "Computed Year",
-        columns = ColumnConstants.COMPUTED_YEAR, tab = EPConstants.TAB_OTHER)
+        columns = ColumnConstants.COMPUTED_YEAR, filterType = {FilterType.REPORTS, FilterType.TAB }, tab = EPConstants.TAB_OTHER)
     public SettingField getComputedYear() {
 	    return FiltersBuilder.buildComputedYears();
 	}


### PR DESCRIPTION
AMP-25125 Hide Computed Year filter in GIS and Dashboard