### PR TITLE
(pre) AMP-25644: Do not allow hierarchy by Indicator in report wizard for tabs

### DIFF
--- a/amp/repository/aim/view/reportWizard/dhtmlReportWizard_step2.jsp
+++ b/amp/repository/aim/view/reportWizard/dhtmlReportWizard_step2.jsp
@@ -94,7 +94,7 @@
 		</tr>
 		<tr>
 			<td align="center" valign="top">
-				<span id="measureOrHierarchyMust2" class="color: red">
+				<span id="measureOrHierarchyMust2" class="color: red" style="display: none;">
 					* <digi:trn>Must select at least one measure or hierarchy</digi:trn>
 				</span>
 			</td>

--- a/amp/repository/aim/view/reportWizard/dhtmlReportWizard_step3.jsp
+++ b/amp/repository/aim/view/reportWizard/dhtmlReportWizard_step3.jsp
@@ -73,7 +73,7 @@
 									</font>
 									</span>
 									<br>
-									<span id="measureOrHierarchyMust3" class="color: red">
+									<span id="measureOrHierarchyMust3" class="color: red" style="display: none;">
 										* <digi:trn>Must select at least one measure or hierarchy</digi:trn>
 									</span>
                                     <br>

--- a/amp/repository/aim/view/reportWizard/dhtmlReportWizard_step4.jsp
+++ b/amp/repository/aim/view/reportWizard/dhtmlReportWizard_step4.jsp
@@ -60,7 +60,7 @@
 											* <digi:trn>The following hierarchies can be used only in reports without measures:</digi:trn>
 											  <div id="measurelessOnlyHiersNotAllowedList"></div>
 										</div>
-										<div id="measureOrHierarchyMust4" class="color: red">
+										<div id="measureOrHierarchyMust4" class="color: red" style="display: none;">
 											* <digi:trn>Must select at least one measure or hierarchy</digi:trn>
 										</div>
 									</td>

--- a/amp/repository/aim/view/scripts/reportWizard/fundingGroups.js
+++ b/amp/repository/aim/view/scripts/reportWizard/fundingGroups.js
@@ -149,6 +149,11 @@ function checkIfColIsHierarchy(id) {
 		}
 	}
 	if (fgArray == null) return false;
+
+	if (repManager.forDesktopTabs
+		&& YAHOO.amp.reportwizard.fundingGroups["measureless_only_hierarchies"].indexOf(colName) >= 0) {
+		return false;
+	}
 	
 	for (j=0; j<fgArray.length; j++) {
 		if ( fgArray[j]==colName ) 

--- a/amp/repository/aim/view/scripts/reportWizard/reportManager.js
+++ b/amp/repository/aim/view/scripts/reportWizard/reportManager.js
@@ -627,6 +627,8 @@ NormalReportManager.prototype.cancelWizard	= function () {
 }
 NormalReportManager.prototype.showHideHierarchies	= function(){};
 
+NormalReportManager.prototype.forDesktopTabs = false;
+
 
 TabReportManager.prototype					= new NormalReportManager();
 TabReportManager.prototype.constructor		= TabReportManager;
@@ -689,6 +691,7 @@ TabReportManager.prototype.checkMeasures	= function () {
 TabReportManager.prototype.cancelWizard	= function () {
 	window.location = "/viewTeamReports.do?tabs=true";
 }
+TabReportManager.prototype.forDesktopTabs = true;
 
 OPTabReportManager.prototype.showHideHierarchies	= function(){};
 


### PR DESCRIPTION
AMP-25644: Do not allow hierarchy by Indicator in report wizard for tabs