### PR TITLE
AMP-25648 applied filters is not shown in public reports

### DIFF
--- a/amp/WEB-INF/src/org/dgfoundation/amp/ar/AmpARFilter.java
+++ b/amp/WEB-INF/src/org/dgfoundation/amp/ar/AmpARFilter.java
@@ -681,10 +681,10 @@ public class AmpARFilter extends PropertyListable {
 		
 		setCalendarType(getWorkspaceCalendar());
 		AmpApplicationSettings settings = getEffectiveSettings();
-		if (settings != null){
+		if (settings != null) {
 			this.setCurrency(settings.getCurrency());
 		} else {
-			this.setCurrency(CurrencyUtil.getBaseCurrency());			
+			this.setCurrency(CurrencyUtil.getBaseCurrency());
 		}		
 		initRenderStartEndYears(settings);
 	}


### PR DESCRIPTION
AMP-25648 applied filters is not shown in public reports - this issue
occurs because currency code is missing in the settings returned by
/rest/data/report/run/:reportToken EP. I have modified the BE to return the GS base currency if no currency is set on the report generator.