### PR TITLE
AMP-26117 GPI reports title

### DIFF
--- a/amp/TEMPLATE/reamp/modules/gpi-reports/styles/main.less
+++ b/amp/TEMPLATE/reamp/modules/gpi-reports/styles/main.less
@@ -269,6 +269,7 @@ a:hover {
 .title-bar h2 {
   font-size: 17px;
   margin: 15px 0 35px 0;
+  font-weight: bold;
 }
 /*indicator tabs*/
 .indicator-tabs li.active a {


### PR DESCRIPTION
- Page Title should be 'Global Partnership Reports' - this had already been implemented.
- Title should be bold