### PR TITLE
AMP-26540: Fixed amp_columns_filters_seq

### DIFF
--- a/amp/xmlpatches/2.z13.00.02/AMP-26540-fix-amp-column-filters-seq.xml
+++ b/amp/xmlpatches/2.z13.00.02/AMP-26540-fix-amp-column-filters-seq.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tns:patch closeOnSuccess="true" retryOnFail="true"
+		   xmlns:tns="http://docs.ampdev.net/schemas/xmlpatcher" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		   xsi:schemaLocation="http://docs.ampdev.net/schemas/xmlpatcher ../../doc/xmlpatcher.xsd ">
+	<jira>AMP-26540</jira>
+	<author>ociubotaru</author>
+	<description>Update amp_columns_filters_seq start value</description>
+	<apply>
+		<script>
+			<lang delimiter="@" type="postgres">
+				DO $$
+				declare seqValue integer;
+				begin
+				SELECT MAX(id)+1 into seqValue FROM amp_columns_filters;
+				EXECUTE 'ALTER SEQUENCE amp_columns_filters_seq RESTART WITH ' || seqValue;
+				END$$@
+			</lang>
+		</script>
+	</apply>
+</tns:patch>


### PR DESCRIPTION
This patch is similar to AMP-22469-update-column-filter-sequence-start-value.xml except that it adds 1 to max(id).