### PR TITLE
AMP-26649: Fixed field size detection

### DIFF
--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/activity/AmpFieldInfoProvider.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/activity/AmpFieldInfoProvider.java
@@ -70,7 +70,7 @@ public class AmpFieldInfoProvider implements FieldInfoProvider {
         }
         AbstractEntityPersister entityPersister = (AbstractEntityPersister) meta;
         String[] propertyNames = entityPersister.getPropertyNames();
-        final String tableName = entityPersister.getTableName();
+        final String tableName = entityPersister.getTableName().toLowerCase();
         Map<String, Field> interchangeableFields = getInterchangeableFields(clazz);
         PersistenceManager.getSession().doWork(new Work() {
             public void execute(Connection conn) throws SQLException {


### PR DESCRIPTION
Postgres is using lower case names by default. The only case when it does otherwise is when names are surrounded by double quotes. We are introspecting hibernate metadata and I believe hibernate does not use double quotes for DDL & DML queries.