### PR TITLE
AMP-25563: Don't fail pipeline if checkstyle violations are found

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,8 +58,6 @@ stage('Checkstyle') {
                 updateGitHubCommitStatus('jenkins/checkstyle', 'Checkstyle success', 'SUCCESS')
             } catch(e) {
                 updateGitHubCommitStatus('jenkins/checkstyle', 'Checkstyle found violations', 'ERROR')
-
-                throw e
             }
         }
     }


### PR DESCRIPTION
(cherry picked from commit 184c5b9)