### PR TITLE
AMP-26000 IE- GPI Data: Date sort does not work as expected

### DIFF
--- a/amp/TEMPLATE/reamp/modules/gpi-data/api/AidOnBudgetApi.jsx
+++ b/amp/TEMPLATE/reamp/modules/gpi-data/api/AidOnBudgetApi.jsx
@@ -2,7 +2,7 @@ import { postJson, delay, fetchJson, deleteJson } from 'amp/tools';
 class AidOnBudgetApi {  
     
     static getAidOnBudgetList(data) { 
-        const url = '/rest/gpi/aid-on-budget?offset=' + data.paging.offset + '&count=' + data.paging.recordsPerPage + '&orderby=' + data.sorting.orderBy + '&sort=' + data.sorting.sortOrder;    
+        const url = '/rest/gpi/aid-on-budget?offset=' + data.paging.offset + '&count=' + data.paging.recordsPerPage + '&orderby=' + data.sorting.orderBy + '&sort=' + data.sorting.sortOrder + '&timestamp=' + Date.now();   
         return new Promise((resolve, reject) => {
             fetchJson(url).then((response) => {
                 resolve(response)

--- a/amp/TEMPLATE/reamp/modules/gpi-data/api/DonorNotesApi.jsx
+++ b/amp/TEMPLATE/reamp/modules/gpi-data/api/DonorNotesApi.jsx
@@ -11,13 +11,13 @@ class DonorNotesApi {
         });
     }
     
-    static getDonorNotesList(data, indicatorCode) { 
-        const url = '/rest/gpi/donor-notes/'+ indicatorCode + '?offset=' + data.paging.offset + '&count=' + data.paging.recordsPerPage + '&orderby=' + data.sorting.orderBy + '&sort=' + data.sorting.sortOrder;    
-        return new Promise((resolve, reject) => {
-            fetchJson(url).then((response) => {
-                resolve(response)
-            }).catch((error) => {
-                reject(error);
+    static getDonorNotesList( data, indicatorCode ) {
+        const url = '/rest/gpi/donor-notes/' + indicatorCode + '?offset=' + data.paging.offset + '&count=' + data.paging.recordsPerPage + '&orderby=' + data.sorting.orderBy + '&sort=' + data.sorting.sortOrder + '&timestamp=' + Date.now();
+        return new Promise(( resolve, reject ) => {
+            fetchJson( url ).then(( response ) => {
+                resolve( response )
+            }).catch(( error ) => {
+                reject( error );
             });
         });
     }


### PR DESCRIPTION
AMP-26000 IE- GPI Data: Date sort does not work as expected, add timestamp to GET requests to prevent caching