### PR TITLE
AMP-26903: Ignore maximum line length checkstyle check for import and package statements

### DIFF
--- a/amp/pom.xml
+++ b/amp/pom.xml
@@ -1004,7 +1004,7 @@
             <plugin>
                 <groupId>org.developmentgateway</groupId>
                 <artifactId>inccheckstyle-maven-plugin</artifactId>
-                <version>0.1</version>
+                <version>0.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
inccheckstyle-maven-plugin version 0.2 uses latest checkstyle 8.2 which by default ignores import and package statements. 