### PR TITLE
AMP-26944 Add Hack to prevent mutiple requests of structures

### DIFF
--- a/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/map/views/structures-view.js
+++ b/amp/TEMPLATE/ampTemplate/gisModule/dev/app/js/amp/map/views/structures-view.js
@@ -357,9 +357,8 @@ module.exports = Backbone.View
   // ==================
   // Layer management
   // ==================
-  showLayer: function(layer) {
+  showLayer: _.debounce(function(layer) {	
     var self = this;
-
     if (this.layerLoadState === 'loading') {
       console.warn('ProjectSites leaflet: tried to show project sites while they are still loading');
       return;
@@ -376,11 +375,11 @@ module.exports = Backbone.View
 
     this.map.on('zoomend', this._updateZoom, this);
 
-  },
+  }, 2000),
 
   refreshLayer: function() {
     // TODO: this is getting called twice when showing sturctures
-    this.hideLayer();
+	this.hideLayer();
     this.showLayer(this.structureMenuModel);
   },
 
@@ -391,7 +390,7 @@ module.exports = Backbone.View
   },
 
   hideLayer: function() {
-    if (this.layerLoadState === 'pending') {
+	if (this.layerLoadState === 'pending') {
       console.warn('Tried to remove project sites but they have not been added');
     } else if (this.layerLoadState === 'loading') {
       console.warn('Project Sites: removing layers while they are loading is not yet supported');


### PR DESCRIPTION
AMP-26944 Add Hack to prevent multiple requests of structures - this is a workaround for a FE bug. Every time the projects sites option is turned on two data requests are made to the BE. I could not figure out the exact source of the event that triggers the second request.  I have wrapped the showLayers with underscore debounce to prevent multiple quick calls to the function.