### PR TITLE
AMP-27026 Filters do not get saved in Desktop Tabs - hotfix/v2.13.0.4 

### DIFF
--- a/amp/TEMPLATE/ampTemplate/tabs/js/models/content.js
+++ b/amp/TEMPLATE/ampTemplate/tabs/js/models/content.js
@@ -29,21 +29,7 @@ define([ 'underscore', 'backbone', 'documentModel' ], function(_, Backbone, Docu
 			}
 		},
 		filtersToJSON : function() {
-			  var json = _.clone(this.get('reportMetadata').get('reportSpec').get('filters').attributes);
-			  for(var attr in json) {
-			    if((json[attr] instanceof Backbone.Model) || (json[attr] instanceof Backbone.Collection)) {
-			    	if (json[attr] instanceof Backbone.Collection){
-			    		var arr = [];
-			    		json[attr].each(function(m) {
-			    			arr.push(m.toJSON());
-			    	    });
-			    		json[attr] = arr;
-			    	} else {
-			    		json[attr] = json[attr].toJSON();
-			    	}			               
-			    }
-			  }
-			  return {filters:json};
+			return _.clone(this.rawFilters);			 
 		}
 	});
 


### PR DESCRIPTION
AMP-27026 Filters do not get saved in Desktop Tabs - modify how we get filters in the JSON format