### PR TITLE
(hotfix 2.13.1.1)AMP-26309 add more spacing between green (i) icon and header

### DIFF
--- a/amp/TEMPLATE/reamp/modules/gpi-reports/styles/main.less
+++ b/amp/TEMPLATE/reamp/modules/gpi-reports/styles/main.less
@@ -570,7 +570,7 @@ a:hover {
 }
 .table-icon {  
   height: 12px;
-  margin-right: 1px;
+  margin-right: 5px;
   margin-top: 1px;
   opacity: 1;  
   margin-bottom: 2px;


### PR DESCRIPTION
AMP-26309 add more spacing between green (i) icon and header