### PR TITLE
AMP-28301 omit structures with invalid latitude or longitude

### DIFF
--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/gis/GisEndPoints.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/gis/GisEndPoints.java
@@ -159,9 +159,9 @@ public class GisEndPoints implements ErrorReportingEndpoint {
             AmpStructure structure = al.get(start);
             FeatureGeoJSON fgj = LocationService.buildFeatureGeoJSON(structure);
             if (fgj != null) {
-            	f.features.add(fgj);
+                f.features.add(fgj);
             }
-            
+
         }
         return f;
     }

--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/gis/GisEndPoints.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/gis/GisEndPoints.java
@@ -157,7 +157,11 @@ public class GisEndPoints implements ErrorReportingEndpoint {
         
         for (; start <= end; start++) {
             AmpStructure structure = al.get(start);
-            f.features.add(LocationService.buildFeatureGeoJSON(structure));
+            FeatureGeoJSON fgj = LocationService.buildFeatureGeoJSON(structure);
+            if (fgj != null) {
+            	f.features.add(fgj);
+            }
+            
         }
         return f;
     }

--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/gis/services/LocationService.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/gis/services/LocationService.java
@@ -419,6 +419,8 @@ public class LocationService {
             logger.warn("Couldn't get parse latitude/longitude for structure with latitude: "
                     + structure.getLatitude() + " longitude: " + structure.getLongitude() + " and title: "
                     + structure.getTitle());
+            
+            return null;
         }
 
         return fgj;


### PR DESCRIPTION
AMP-28301 omit structures with invalid latitude or longitude from the EP
response. They cause issues on the FE.