### PR TITLE
AMP-30013: Display user friendly messages when geocoding is not available

### DIFF
--- a/amp/TEMPLATE/reampv2/src/modules/geocoder/actions/geocodingAction.js
+++ b/amp/TEMPLATE/reampv2/src/modules/geocoder/actions/geocodingAction.js
@@ -60,10 +60,15 @@ export function fetchGeocodingNotFound(geocoding) {
 
 
 export function fetchGeocodingError(error, status) {
+    return fetchGeocodingErrorWithCode(error, status, null);
+}
+
+export function fetchGeocodingErrorWithCode(error, status, code) {
     return {
         type: FETCH_GEOCODING_ERROR,
         error: error,
-        status: status
+        status: status,
+        errorCode: code
     }
 }
 
@@ -213,7 +218,7 @@ export const loadGeocoding = () => {
                 if(isGeocodingNotFound(error)) {
                     return dispatch(fetchGeocodingNotFound(null));
                 }
-                return dispatch(fetchGeocodingError(error.message, "NOT_AVAILABLE"))
+                return dispatch(fetchGeocodingErrorWithCode(error.message, "NOT_AVAILABLE", error.code))
             });
     }
 };

--- a/amp/TEMPLATE/reampv2/src/modules/geocoder/components/layout/panel/AlertError.jsx
+++ b/amp/TEMPLATE/reampv2/src/modules/geocoder/components/layout/panel/AlertError.jsx
@@ -1,14 +1,36 @@
 import React, {Component} from "react";
 import Alert from "react-bootstrap/Alert";
+import {TranslationContext} from "../../AppContext";
+import {formatText} from "../../../../../utils/Utils";
 
 export default class AlertError extends Component {
     render() {
-        let {error} = this.props;
+        const {translations} = this.context;
+
+        let errorMessage = getErrorMessage(translations, this.props);
+
         return (
             <Alert variant="danger" show={true} transition={false}>
                 <Alert.Heading>Sorry, there was a problem</Alert.Heading>
-                <p>{error}</p>
+                <p>{errorMessage}</p>
             </Alert>
         );
     }
 }
+
+function getErrorMessage(translations, {errorCode, error}) {
+    let errorMessageCode = 'amp.geocoder:error.' + errorCode;
+
+    if (translations.hasOwnProperty(errorMessageCode)) {
+        if (errorCode === '1704' || errorCode === '1705') {
+            let errorObj = JSON.parse(error);
+            return formatText(translations[errorMessageCode], errorObj[0][Object.keys(errorObj[0])[0]][0]);
+        } else {
+            return translations[errorMessageCode];
+        }
+    }
+
+    return error;
+}
+
+AlertError.contextType = TranslationContext;

--- a/amp/TEMPLATE/reampv2/src/modules/geocoder/components/layout/panel/GeocoderPanel.jsx
+++ b/amp/TEMPLATE/reampv2/src/modules/geocoder/components/layout/panel/GeocoderPanel.jsx
@@ -72,7 +72,7 @@ class GeocoderPanel extends Component {
             <div>
             {/*{isGeocodingNotAvailable && <GeocodingNotAvailable user={this.props.geocoding.creator} workspace={this.props.geocoding.workspace}/>}*/}
                 {this.props.geocoding.error
-                    ?  <AlertError error={this.props.geocoding.error}/>
+                    ?  <AlertError error={this.props.geocoding.error} errorCode={this.props.geocoding.errorCode}/>
                     : <div>
                         <ProjectList title={title}/>
                         <div className='panel panel-default'>

--- a/amp/TEMPLATE/reampv2/src/modules/geocoder/config/initialTranslations.json
+++ b/amp/TEMPLATE/reampv2/src/modules/geocoder/config/initialTranslations.json
@@ -13,5 +13,7 @@
   "amp.geocoder:ok": "OK",
   "amp.geocoder:noLocations": "No locations",
   "amp.geocoder:discardGeocodingButton": "Discard Geocoding",
-  "amp.geocoder:discardGeocodingText": "There is no geocoded location found. You can cancel the geocoding process."
+  "amp.geocoder:discardGeocodingText": "There is no geocoded location found. You can cancel the geocoding process.",
+  "amp.geocoder:error.1704": "The Current Geocoding process was created by user '{0}' and is not available. Please contact them to get more details. Once that process is done another one will be able to be launched.",
+  "amp.geocoder:error.1705": "The current Geocoding process was created in the '{0}' workspace and it is available only in that workspace. Please login to that workspace to see the geocoding process status."
 }

--- a/amp/TEMPLATE/reampv2/src/modules/geocoder/reducers/geocodingReducer.js
+++ b/amp/TEMPLATE/reampv2/src/modules/geocoder/reducers/geocodingReducer.js
@@ -50,7 +50,8 @@ export default function geocodingReducer(state = initialState, action) {
                 status: action.status,
                 pending: action.pending,
                 geocodeShouldRun: action.geocodeShouldRun,
-                error: null
+                error: null,
+                errorCode: null
             };
         case FETCH_GEOCODING_ERROR:
             return {
@@ -59,6 +60,7 @@ export default function geocodingReducer(state = initialState, action) {
                 error: action.error,
                 geocodeShouldRun: false,
                 status : action.status,
+                errorCode: action.errorCode
             };
         case GEOCODING_RUN_SEARCH_SUCCESS:
             return {

--- a/amp/TEMPLATE/reampv2/src/utils/Utils.js
+++ b/amp/TEMPLATE/reampv2/src/utils/Utils.js
@@ -7,3 +7,11 @@ export function getRootUrl() {
     return `${process.env.PUBLIC_URL}/index.html#`;
   }
 }
+
+export function formatText(text) {
+    var args = arguments;
+    return text.replace(/{(\d+)}/g, function (match, number) {
+        let argIdx = parseInt(number) + 1;
+        return typeof args[argIdx] != 'undefined' ? args[argIdx] : match;
+    });
+};

--- a/amp/TEMPLATE/reampv2/src/utils/apiOperations.js
+++ b/amp/TEMPLATE/reampv2/src/utils/apiOperations.js
@@ -56,7 +56,9 @@ export const fetchApiDataWithStatus = ({body, url}) => {
                 })
             ).then(response => {
                 if (!response.ok) {
-                    return reject({status: response.status, message: extractErrorMessageFromResponse(response)});
+                    return reject({status: response.status,
+                        message: extractErrorMessageFromResponse(response),
+                        code: extractErrorCodeFromResponse(response)});
                 }
 
                 return resolve(response);
@@ -65,11 +67,17 @@ export const fetchApiDataWithStatus = ({body, url}) => {
 };
 
 export function extractErrorMessageFromResponse(response) {
-    let errorMessage = response.status + ": ";
+    let errorMessage = "";
 
     for(let k in response.data.error) {
-        errorMessage += response.data.error[k][0] + "\n";
+        errorMessage += JSON.stringify(response.data.error[k]);
     };
 
     return errorMessage;
+}
+
+export function extractErrorCodeFromResponse(response) {
+    for(let k in response.data.error) {
+        return k;
+    };
 }

--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/errors/ApiError.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/errors/ApiError.java
@@ -3,7 +3,6 @@ package org.digijava.kernel.ampapi.endpoints.errors;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -16,6 +15,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang.StringUtils;
 import org.dgfoundation.amp.algo.AlgoUtils;
 import org.digijava.kernel.ampapi.endpoints.activity.ActivityErrors;
@@ -28,6 +28,7 @@ import org.digijava.kernel.ampapi.endpoints.contact.ContactErrors;
 import org.digijava.kernel.ampapi.endpoints.currency.CurrencyErrors;
 import org.digijava.kernel.ampapi.endpoints.dashboards.DashboardErrors;
 import org.digijava.kernel.ampapi.endpoints.datafreeze.DataFreezeErrors;
+import org.digijava.kernel.ampapi.endpoints.geocoding.GeoCoderEndpoint;
 import org.digijava.kernel.ampapi.endpoints.gpi.GPIErrors;
 import org.digijava.kernel.ampapi.endpoints.indicator.IndicatorErrors;
 import org.digijava.kernel.ampapi.endpoints.performance.PerformanceRulesErrors;
@@ -105,7 +106,7 @@ public class ApiError {
     }
 
     private final static Set<String> COMPONENTS_WITH_NEW_ERROR_FORMAT = new HashSet<>(
-            Collections.singletonList(InterchangeEndpoints.class.getName()));
+            ImmutableList.of(InterchangeEndpoints.class.getName(), GeoCoderEndpoint.class.getName()));
 
     /**
      * Returns an ApiErrorResponse object with a single error message

--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/geocoding/GeoCoderEndpoint.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/geocoding/GeoCoderEndpoint.java
@@ -1,18 +1,5 @@
 package org.digijava.kernel.ampapi.endpoints.geocoding;
 
-import java.util.Set;
-
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -27,6 +14,20 @@ import org.digijava.kernel.entity.geocoding.GeoCodingProcess;
 import org.digijava.kernel.geocoding.service.GeneralGeoCodingException;
 import org.digijava.kernel.geocoding.service.GeoCodingNotAvailableException;
 import org.digijava.kernel.geocoding.service.GeoCodingService;
+import org.digijava.module.aim.dbentity.AmpTeamMember;
+import org.digijava.module.aim.util.TeamUtil;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Set;
 
 /**
  * @author Octavian Ciubotaru
@@ -82,9 +83,20 @@ public class GeoCoderEndpoint {
             }
             return process;
         } catch (GeoCodingNotAvailableException e) {
-            ApiErrorResponse apiErrorResponse = ApiError.toError(
-                    GeoCoderEndpointErrors.GEO_CODING_NOT_AVAILABLE.withDetails(e.getTeamMember().toString()));
-            throw new ApiRuntimeException(Response.Status.BAD_REQUEST, apiErrorResponse);
+            AmpTeamMember currentTM = TeamUtil.getCurrentAmpTeamMember();
+            AmpTeamMember geocoderTM = e.getTeamMember();
+
+            if (!currentTM.getUser().getId().equals(geocoderTM.getUser().getId())) {
+                throw new ApiRuntimeException(Response.Status.BAD_REQUEST, ApiError.toError(
+                        GeoCoderEndpointErrors.GEO_CODING_INVALID_USER.withDetails(geocoderTM.getUser().getName())));
+            } else if (!currentTM.getAmpTeam().getAmpTeamId().equals(geocoderTM.getAmpTeam().getAmpTeamId())) {
+                throw new ApiRuntimeException(Response.Status.BAD_REQUEST, ApiError.toError(
+                        GeoCoderEndpointErrors.GEO_CODING_INVALID_WORKSPACE
+                                .withDetails(geocoderTM.getAmpTeam().getName())));
+            }
+
+            throw new ApiRuntimeException(Response.Status.BAD_REQUEST, ApiError.toError(
+                    GeoCoderEndpointErrors.GEO_CODING_NOT_AVAILABLE));
         }
     }
 

--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/geocoding/GeoCoderEndpointErrors.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/geocoding/GeoCoderEndpointErrors.java
@@ -20,5 +20,9 @@ public final class GeoCoderEndpointErrors {
             "Geo coding process not started");
     public static final ApiErrorMessage GEO_CODING_ACT_SAVE_ERROR = new ApiErrorMessage(ERROR_CLASS_GEO_CODER_ID, 3,
             "Activity not saved");
+    public static final ApiErrorMessage GEO_CODING_INVALID_USER = new ApiErrorMessage(ERROR_CLASS_GEO_CODER_ID, 4,
+            "Invalid User");
+    public static final ApiErrorMessage GEO_CODING_INVALID_WORKSPACE = new ApiErrorMessage(ERROR_CLASS_GEO_CODER_ID, 5,
+            "Invalid Workspace");
 
 }


### PR DESCRIPTION
The main problem is that the current API Error messaging doesn't allow to send a response with-param that could be used to format user-friendly messages.