### PR TITLE
AMP-30409: Inconsistency in dash vs report data caused by difference …

### DIFF
--- a/amp/TEMPLATE/ampTemplate/node_modules/amp-filter/src/utils/constants.js
+++ b/amp/TEMPLATE/ampTemplate/node_modules/amp-filter/src/utils/constants.js
@@ -44,6 +44,7 @@ var constants = {
     YEAR_SINGLE_VALUE: 'YEAR-SINGLE-VALUE',
     CONTEXT_DASHBOARD: 'DASHBOARD',
     CONTEXT_GIS: 'GIS',
+    CONTEXT_REPORT: 'REPORTS',
     FUNDING_ORGANIZATIONS: 'Funding Organizations',
     ACTIVITY: 'Activity',
     ALL_AGENCIES: 'All Agencies',

--- a/amp/TEMPLATE/ampTemplate/node_modules/amp-filter/src/views/filters-view.js
+++ b/amp/TEMPLATE/ampTemplate/node_modules/amp-filter/src/views/filters-view.js
@@ -579,8 +579,10 @@ module.exports = Backbone.View.extend({
             return DateUtils.extractDates(self.settings, blob, 'dashboard-default-min-date', 'dashboard-default-max-date');
         } else if (self.caller === Constants.CONTEXT_GIS) {
             return DateUtils.extractDates(self.settings, blob, 'gis-default-min-date', 'gis-default-max-date');
+        } else if (self.caller === Constants.CONTEXT_REPORT) {
+            return DateUtils.extractDates(self.settings, blob, 'report-default-min-date', 'report-default-max-date');
         }
-        return blob
+        return blob;
     },
 
     cancel: function () {

--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/common/AmpGeneralSettings.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/common/AmpGeneralSettings.java
@@ -133,6 +133,17 @@ public class AmpGeneralSettings {
     @JsonProperty(SettingsConstants.GIS_DEFAULT_MIN_YEAR_RANGE)
     private String gisDefaultMinYearRange;
 
+    @JsonProperty(SettingsConstants.REPORT_DEFAULT_MAX_DATE)
+    private String reportDefaultMaxDate;
+
+    @JsonProperty(SettingsConstants.REPORT_DEFAULT_MIN_DATE)
+    private String reportDefaultMinDate;
+
+    @JsonProperty(SettingsConstants.REPORT_DEFAULT_MAX_YEAR_RANGE)
+    private String reportDefaultMaxYearRange;
+    @JsonProperty(SettingsConstants.REPORT_DEFAULT_MIN_YEAR_RANGE)
+    private String reportDefaultMinYearRange;
+
     public Boolean getUseIconsForSectorsInProjectList() {
         return useIconsForSectorsInProjectList;
     }
@@ -475,5 +486,38 @@ public class AmpGeneralSettings {
 
     public void setNddMappingProgramLevel(Integer nddMappingProgramLevel) {
         this.nddMappingProgramLevel = nddMappingProgramLevel;
+    }
+
+    public String getReportDefaultMinDate() {
+        return reportDefaultMinDate;
+    }
+
+    public void setReportDefaultMinDate(String reportDefaultMinDate) {
+        this.reportDefaultMinDate = reportDefaultMinDate;
+    }
+
+
+    public String getReportDefaultMaxDate() {
+        return reportDefaultMaxDate;
+    }
+
+    public void setReportDefaultMaxDate(String reportDefaultMaxDate) {
+        this.reportDefaultMaxDate = reportDefaultMaxDate;
+    }
+
+    public void setReportDefaultMaxYearRange(String reportDefaultMaxYearRange) {
+        this.reportDefaultMaxYearRange = reportDefaultMaxYearRange;
+    }
+
+    public void setReportDefaultMinYearRange(String reportDefaultMinYearRange) {
+        this.reportDefaultMinYearRange = reportDefaultMinYearRange;
+    }
+
+    public String getReportDefaultMaxYearRange() {
+        return reportDefaultMaxYearRange;
+    }
+
+    public String getReportDefaultMinYearRange() {
+        return reportDefaultMinYearRange;
     }
 }

--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/settings/SettingsConstants.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/settings/SettingsConstants.java
@@ -70,6 +70,13 @@ public class SettingsConstants {
     public static final String GIS_DEFAULT_MAX_DATE = "gis-default-max-date";
     public static final String GIS_DEFAULT_MIN_DATE = "gis-default-min-date";
 
+    public static final String REPORT_DEFAULT_MAX_DATE = "report-default-max-date";
+
+    public static final String REPORT_DEFAULT_MIN_DATE = "report-default-min-date";
+
+    public static final String REPORT_DEFAULT_MAX_YEAR_RANGE = "report-default-max-year-range";
+    public static final String REPORT_DEFAULT_MIN_YEAR_RANGE = "report-default-min-year-range";
+
 
 
 

--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/settings/SettingsUtils.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/settings/SettingsUtils.java
@@ -503,6 +503,13 @@ public class SettingsUtils {
         addDateSetting(settings, GlobalSettingsConstants.GIS_DEFAUL_MIN_YEAR_RANGE,
                 SettingsConstants.GIS_DEFAULT_MIN_DATE, SettingsConstants.GIS_DEFAULT_MIN_YEAR_RANGE,
                 gsFiscalCalendar, currentCalendar, false);
+        addDateSetting(settings, Constants.GlobalSettings.END_YEAR_DEFAULT_VALUE,
+                SettingsConstants.REPORT_DEFAULT_MAX_DATE, SettingsConstants.REPORT_DEFAULT_MAX_DATE,
+                gsFiscalCalendar, currentCalendar, true);
+        addDateSetting(settings, Constants.GlobalSettings.START_YEAR_DEFAULT_VALUE,
+                SettingsConstants.REPORT_DEFAULT_MIN_DATE, SettingsConstants.REPORT_DEFAULT_MIN_DATE,
+                gsFiscalCalendar, currentCalendar, false);
+
     }
 
     private static void addDateSetting(AmpGeneralSettings settings, String globalSettingsName, String dateSettingsName,
@@ -518,6 +525,10 @@ public class SettingsUtils {
             settings.setGisDefaultMaxYearRange(yearNumber);
         } else if (yearSettingsName.equals(SettingsConstants.GIS_DEFAULT_MIN_YEAR_RANGE)) {
             settings.setGisDefaultMinYearRange(yearNumber);
+        } else if (yearSettingsName.equals(SettingsConstants.REPORT_DEFAULT_MAX_YEAR_RANGE)) {
+            settings.setReportDefaultMaxYearRange(yearNumber);
+        } else if (yearSettingsName.equals(SettingsConstants.REPORT_DEFAULT_MIN_YEAR_RANGE)) {
+            settings.setReportDefaultMinYearRange(yearNumber);
         }
 
         if (!StringUtils.equals(yearNumber, "-1")) {
@@ -541,6 +552,10 @@ public class SettingsUtils {
                 settings.setGisDefaultMaxDate(formattedDate);
             } else if (dateSettingsName.equals(SettingsConstants.GIS_DEFAULT_MIN_DATE)) {
                 settings.setGisDefaultMinDate(formattedDate);
+            } else if (dateSettingsName.equals(SettingsConstants.REPORT_DEFAULT_MAX_DATE)) {
+                settings.setReportDefaultMaxDate(formattedDate);
+            } else if (dateSettingsName.equals(SettingsConstants.REPORT_DEFAULT_MIN_DATE)) {
+                settings.setReportDefaultMinDate(formattedDate);
             }
         }
     }

--- a/amp/deployConfigs/selected.properties
+++ b/amp/deployConfigs/selected.properties
@@ -1,4 +1,4 @@
 #Description of the selected config
 #Wed, 22 Mar 2023 22:01:17 +0300
-
+#
 serverName=local


### PR DESCRIPTION
…in date range in global settings vs real dash. Reports were not displaying date property, setting start and end date to default