### PR TITLE
Task/amp 30430/sector not empty fix date format

### DIFF
--- a/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/indicator/manager/MEIndicatorDTO.java
+++ b/amp/WEB-INF/src/org/digijava/kernel/ampapi/endpoints/indicator/manager/MEIndicatorDTO.java
@@ -5,13 +5,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.digijava.kernel.ampapi.endpoints.indicator.manager.validators.*;
+import io.swagger.annotations.ApiModelProperty;
+import org.digijava.kernel.ampapi.endpoints.indicator.manager.validators.ValidSectorIds;
 import org.digijava.kernel.ampapi.endpoints.serializers.LocalizedDateDeserializer;
 import org.digijava.kernel.ampapi.endpoints.serializers.LocalizedDateSerializer;
 import org.digijava.module.aim.dbentity.AmpIndicator;
 import org.digijava.module.aim.dbentity.AmpIndicatorGlobalValue;
 import org.digijava.module.aim.dbentity.AmpSector;
+import org.hibernate.validator.constraints.NotEmpty;
 
-import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Date;
@@ -48,6 +50,7 @@ public class MEIndicatorDTO {
     @JsonSerialize(using = LocalizedDateSerializer.class)
     @JsonDeserialize(using = LocalizedDateDeserializer.class)
     @NotNull
+    @ApiModelProperty(dataType = "java.util.date", example = "02/02/2023")
     private Date creationDate;
 
     @JsonProperty("base")

--- a/amp/WEB-INF/src/org/digijava/module/aim/dbentity/AmpIndicatorGlobalValue.java
+++ b/amp/WEB-INF/src/org/digijava/module/aim/dbentity/AmpIndicatorGlobalValue.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import io.swagger.annotations.ApiModelProperty;
 import org.digijava.kernel.ampapi.endpoints.serializers.LocalizedDateDeserializer;
 import org.digijava.kernel.ampapi.endpoints.serializers.LocalizedDateSerializer;
 
@@ -33,6 +34,7 @@ public class AmpIndicatorGlobalValue implements Serializable {
     @JsonSerialize(using = LocalizedDateSerializer.class)
     @JsonDeserialize(using = LocalizedDateDeserializer.class)
     @JsonProperty("originalValueDate")
+    @ApiModelProperty(dataType = "java.util.date", example = "02/02/2023")
     private Date originalValueDate;
 
     @JsonProperty("revisedValue")
@@ -41,6 +43,7 @@ public class AmpIndicatorGlobalValue implements Serializable {
     @JsonSerialize(using = LocalizedDateSerializer.class)
     @JsonDeserialize(using = LocalizedDateDeserializer.class)
     @JsonProperty("revisedValueDate")
+    @ApiModelProperty(dataType = "java.util.date", example = "02/02/2023")
     private Date revisedValueDate;
 
     @JsonIgnore


### PR DESCRIPTION
…format to be dd/MM/yyyy

Sectors can be empty as indicators can be tied to programs