### PR TITLE
AMP-30989: Reopened to correctly change the foreign key

### DIFF
--- a/amp/src/main/resources/xmlpatches/4.0/AMP-30989-Alter-created-by-in-indicator-layer-reopened.xml
+++ b/amp/src/main/resources/xmlpatches/4.0/AMP-30989-Alter-created-by-in-indicator-layer-reopened.xml
@@ -12,6 +12,8 @@
               alter table amp_indicator_layer drop constraint if exists fk_jv9veurrierqhvb1rq6n1e9un;
             -- or Drop created_by amp_team_member foreign key manually
             ALTER TABLE amp_indicator_layer DROP CONSTRAINT IF EXISTS fk_created_by_user;
+            UPDATE amp_indicator_layer set created_by = (select id from dg_user where email = 'admin@amp.org');
+            UPDATE amp_indicator_layer set created_by = NULL where access_type=0;
             ALTER TABLE amp_indicator_layer ADD CONSTRAINT fk_created_by_user FOREIGN KEY (created_by) REFERENCES dg_user(id);
     ]]></lang>
         </script>


### PR DESCRIPTION
@jdeanquin-dg am implicitly reopening this since the last update was not correctly modifying the foreign because there was a NULL condition in the query which meant that the value of created_by was not changed and in turn we are unable to create the new foregin key reference