### PR TITLE
AMP-31192 : Fix external buildability (HTTPS submodules/deps, remove proprietary headers)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "amp/TEMPLATE/ampTemplate/node_modules/amp-boilerplate"]
 	path = amp/TEMPLATE/ampTemplate/node_modules/amp-boilerplate
-	url = git@github.com:devgateway/amp-boilerplate.git
+	url = https://github.com/devgateway/amp-boilerplate.git
 [submodule "amp/TEMPLATE/ampTemplate/node_modules/amp-translate"]
 	path = amp/TEMPLATE/ampTemplate/node_modules/amp-translate
-	url = git@github.com:devgateway/amp-translate.git
+	url = https://github.com/devgateway/amp-translate.git
 [submodule "amp/TEMPLATE/ampTemplate/node_modules/amp-filter"]
 	path = amp/TEMPLATE/ampTemplate/node_modules/amp-filter
-	url = git@github.com:devgateway/amp-filter.git
+	url = https://github.com/devgateway/amp-filter.git

--- a/amp/TEMPLATE/ampTemplate/amp-settings/package-lock.json
+++ b/amp/TEMPLATE/ampTemplate/amp-settings/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
-        "amp-translate": "github:devgateway/amp-translate"
+        "amp-translate": "https://github.com/devgateway/amp-translate.git"
       },
       "devDependencies": {
         "backbone": "1.1.2",
@@ -90,7 +90,7 @@
     },
     "node_modules/amp-translate": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/devgateway/amp-translate.git#c169447fb1cfd728259830ac5564d6dbf31a5380",
+      "resolved": "git+https://github.com/devgateway/amp-translate.git#c169447fb1cfd728259830ac5564d6dbf31a5380",
       "dependencies": {
         "backbone": "1.1.2",
         "jquery": "2.1.1",
@@ -8107,7 +8107,7 @@
       "optional": true
     },
     "amp-translate": {
-      "version": "git+ssh://git@github.com/devgateway/amp-translate.git#c169447fb1cfd728259830ac5564d6dbf31a5380",
+      "version": "git+https://github.com/devgateway/amp-translate.git#c169447fb1cfd728259830ac5564d6dbf31a5380",
       "from": "amp-translate@github:devgateway/amp-translate",
       "requires": {
         "backbone": "1.1.2",

--- a/amp/TEMPLATE/ampTemplate/amp-settings/package-lock.json
+++ b/amp/TEMPLATE/ampTemplate/amp-settings/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
-        "amp-translate": "https://github.com/devgateway/amp-translate.git"
+        "amp-translate": "git+https://github.com/devgateway/amp-translate.git"
       },
       "devDependencies": {
         "backbone": "1.1.2",
@@ -8108,7 +8108,7 @@
     },
     "amp-translate": {
       "version": "git+https://github.com/devgateway/amp-translate.git#c169447fb1cfd728259830ac5564d6dbf31a5380",
-      "from": "amp-translate@github:devgateway/amp-translate",
+      "from": "amp-translate@git+https://github.com/devgateway/amp-translate.git",
       "requires": {
         "backbone": "1.1.2",
         "jquery": "2.1.1",

--- a/amp/TEMPLATE/ampTemplate/amp-settings/package.json
+++ b/amp/TEMPLATE/ampTemplate/amp-settings/package.json
@@ -57,6 +57,6 @@
     "tag": "latest"
   },
   "dependencies": {
-    "amp-translate": "https://github.com/devgateway/amp-translate.git"
+    "amp-translate": "git+https://github.com/devgateway/amp-translate.git"
   }
 }

--- a/amp/TEMPLATE/ampTemplate/dashboard/dev/package-lock.json
+++ b/amp/TEMPLATE/ampTemplate/dashboard/dev/package-lock.json
@@ -14,7 +14,7 @@
         "bootstrap": "~3.4.1",
         "d3": "=3.5.12",
         "jquery": "~2.1.1",
-        "nvd3": "git://github.com/novus/nvd3.git#v1.7.1",
+        "nvd3": "git+https://github.com/novus/nvd3.git#v1.7.1",
         "underscore": "=1.7.0"
       },
       "devDependencies": {
@@ -7671,7 +7671,7 @@
     },
     "node_modules/nvd3": {
       "version": "1.7.1",
-      "resolved": "git+ssh://git@github.com/novus/nvd3.git#679fe2ff96c194e442970cb9959ebccd79f6bd43"
+      "resolved": "git+https://github.com/novus/nvd3.git#679fe2ff96c194e442970cb9959ebccd79f6bd43"
     },
     "node_modules/object-copy": {
       "version": "0.1.0",
@@ -17632,7 +17632,7 @@
       "dev": true
     },
     "nvd3": {
-      "version": "git+ssh://git@github.com/novus/nvd3.git#679fe2ff96c194e442970cb9959ebccd79f6bd43",
+      "version": "git+https://github.com/novus/nvd3.git#679fe2ff96c194e442970cb9959ebccd79f6bd43",
       "from": "nvd3@git://github.com/novus/nvd3.git#v1.7.1"
     },
     "object-copy": {

--- a/amp/TEMPLATE/ampTemplate/dashboard/dev/package-lock.json
+++ b/amp/TEMPLATE/ampTemplate/dashboard/dev/package-lock.json
@@ -17633,7 +17633,7 @@
     },
     "nvd3": {
       "version": "git+https://github.com/novus/nvd3.git#679fe2ff96c194e442970cb9959ebccd79f6bd43",
-      "from": "nvd3@git://github.com/novus/nvd3.git#v1.7.1"
+      "from": "nvd3@git+https://github.com/novus/nvd3.git#v1.7.1"
     },
     "object-copy": {
       "version": "0.1.0",

--- a/amp/TEMPLATE/ampTemplate/dashboard/dev/package.json
+++ b/amp/TEMPLATE/ampTemplate/dashboard/dev/package.json
@@ -45,7 +45,7 @@
     "bootstrap": "~3.4.1",
     "d3": "=3.5.12",
     "jquery": "~2.1.1",
-    "nvd3": "git://github.com/novus/nvd3.git#v1.7.1",
+    "nvd3": "git+https://github.com/novus/nvd3.git#v1.7.1",
     "underscore": "=1.7.0"
   },
   "browserslist": [

--- a/amp/TEMPLATE/reamp/package-lock.json
+++ b/amp/TEMPLATE/reamp/package-lock.json
@@ -9495,7 +9495,7 @@
     "amp-ui": {
       "version": "git+https://github.com/devgateway/amp-ui.git#b033cf93099abd3fd308a1d3080f95ac9ddbb5fd",
       "dev": true,
-      "from": "amp-ui@github:devgateway/amp-ui#fix/AMP-31133/Indicator-values-display-fixes",
+      "from": "amp-ui@git+https://github.com/devgateway/amp-ui.git#fix/AMP-31133/Indicator-values-display-fixes",
       "requires": {
         "docx": "^4.7.1",
         "file-saver": "git+https://github.com/devgateway/FileSaver.js.git",
@@ -11941,7 +11941,7 @@
     "file-saver": {
       "version": "git+https://github.com/devgateway/FileSaver.js.git#20b5a235d8ca3b174b8c5f51dfdff11f9a00cccb",
       "dev": true,
-      "from": "file-saver@github:devgateway/FileSaver.js"
+      "from": "file-saver@git+https://github.com/devgateway/FileSaver.js.git"
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -14960,7 +14960,7 @@
     "react-router-hash-link": {
       "version": "git+https://github.com/rafgraph/react-router-hash-link.git#eb264491c6289cca534a368046a37d9aa3cbc7f7",
       "dev": true,
-      "from": "react-router-hash-link@git://github.com/rafgraph/react-router-hash-link.git#react-router-v2/3",
+      "from": "react-router-hash-link@git+https://github.com/rafgraph/react-router-hash-link.git#react-router-v2/3",
       "requires": {
         "object-assign": "^4.1.0",
         "react": "^15.4.1",

--- a/amp/TEMPLATE/reamp/package-lock.json
+++ b/amp/TEMPLATE/reamp/package-lock.json
@@ -22,7 +22,7 @@
         "uglifyjs-webpack-plugin": "^1.3.0"
       },
       "devDependencies": {
-        "amp-ui": "github:devgateway/amp-ui#fix/AMP-31133/Indicator-values-display-fixes",
+        "amp-ui": "git+https://github.com/devgateway/amp-ui.git#fix/AMP-31133/Indicator-values-display-fixes",
         "babel-core": "^6.26.3",
         "babel-jest": "^6.0.1",
         "babel-loader": "^6.3.2",
@@ -72,11 +72,11 @@
       "license": "MIT",
       "dependencies": {
         "docx": "^4.7.1",
-        "file-saver": "github:devgateway/FileSaver.js",
+        "file-saver": "git+https://github.com/devgateway/FileSaver.js.git",
         "fs": "0.0.1-security",
         "he": "^1.2.0",
         "moment": "^2.18.1",
-        "react-router-hash-link": "git://github.com/rafgraph/react-router-hash-link.git#react-router-v2/3"
+        "react-router-hash-link": "git+https://github.com/rafgraph/react-router-hash-link.git#react-router-v2/3"
       },
       "devDependencies": {
         "@svgr/rollup": "^2.4.1",
@@ -101,7 +101,7 @@
         "eslint-plugin-promise": "^4.0.0",
         "eslint-plugin-react": "^7.10.0",
         "eslint-plugin-standard": "^3.1.0",
-        "file-saver": "git+ssh://github.com/devgateway/FileSaver.js",
+        "file-saver": "git+https://github.com/devgateway/FileSaver.js.git",
         "fs": "0.0.1-security",
         "gh-pages": "^1.2.0",
         "numeral": "^2.0.6",
@@ -309,16 +309,16 @@
     },
     "node_modules/amp-ui": {
       "version": "2.1.1",
-      "resolved": "git+ssh://git@github.com/devgateway/amp-ui.git#b033cf93099abd3fd308a1d3080f95ac9ddbb5fd",
+      "resolved": "git+https://github.com/devgateway/amp-ui.git#b033cf93099abd3fd308a1d3080f95ac9ddbb5fd",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "docx": "^4.7.1",
-        "file-saver": "github:devgateway/FileSaver.js",
+        "file-saver": "git+https://github.com/devgateway/FileSaver.js.git",
         "fs": "0.0.1-security",
         "he": "^1.2.0",
         "moment": "^2.18.1",
-        "react-router-hash-link": "git://github.com/rafgraph/react-router-hash-link.git#react-router-v2/3"
+        "react-router-hash-link": "git+https://github.com/rafgraph/react-router-hash-link.git#react-router-v2/3"
       },
       "engines": {
         "node": ">=16",
@@ -3127,7 +3127,7 @@
     },
     "node_modules/file-saver": {
       "version": "2.0.2",
-      "resolved": "git+ssh://git@github.com/devgateway/FileSaver.js.git#20b5a235d8ca3b174b8c5f51dfdff11f9a00cccb",
+      "resolved": "git+https://github.com/devgateway/FileSaver.js.git#20b5a235d8ca3b174b8c5f51dfdff11f9a00cccb",
       "dev": true,
       "license": "MIT"
     },
@@ -6799,7 +6799,7 @@
     },
     "node_modules/react-router-hash-link": {
       "name": "react-router-hash-link-v2/3",
-      "resolved": "git+ssh://git@github.com/rafgraph/react-router-hash-link.git#eb264491c6289cca534a368046a37d9aa3cbc7f7",
+      "resolved": "git+https://github.com/rafgraph/react-router-hash-link.git#eb264491c6289cca534a368046a37d9aa3cbc7f7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9493,16 +9493,16 @@
       "dev": true
     },
     "amp-ui": {
-      "version": "git+ssh://git@github.com/devgateway/amp-ui.git#b033cf93099abd3fd308a1d3080f95ac9ddbb5fd",
+      "version": "git+https://github.com/devgateway/amp-ui.git#b033cf93099abd3fd308a1d3080f95ac9ddbb5fd",
       "dev": true,
       "from": "amp-ui@github:devgateway/amp-ui#fix/AMP-31133/Indicator-values-display-fixes",
       "requires": {
         "docx": "^4.7.1",
-        "file-saver": "github:devgateway/FileSaver.js",
+        "file-saver": "git+https://github.com/devgateway/FileSaver.js.git",
         "fs": "0.0.1-security",
         "he": "^1.2.0",
         "moment": "^2.18.1",
-        "react-router-hash-link": "git://github.com/rafgraph/react-router-hash-link.git#react-router-v2/3"
+        "react-router-hash-link": "git+https://github.com/rafgraph/react-router-hash-link.git#react-router-v2/3"
       }
     },
     "ansi-regex": {
@@ -11939,7 +11939,7 @@
       }
     },
     "file-saver": {
-      "version": "git+ssh://git@github.com/devgateway/FileSaver.js.git#20b5a235d8ca3b174b8c5f51dfdff11f9a00cccb",
+      "version": "git+https://github.com/devgateway/FileSaver.js.git#20b5a235d8ca3b174b8c5f51dfdff11f9a00cccb",
       "dev": true,
       "from": "file-saver@github:devgateway/FileSaver.js"
     },
@@ -14958,7 +14958,7 @@
       }
     },
     "react-router-hash-link": {
-      "version": "git+ssh://git@github.com/rafgraph/react-router-hash-link.git#eb264491c6289cca534a368046a37d9aa3cbc7f7",
+      "version": "git+https://github.com/rafgraph/react-router-hash-link.git#eb264491c6289cca534a368046a37d9aa3cbc7f7",
       "dev": true,
       "from": "react-router-hash-link@git://github.com/rafgraph/react-router-hash-link.git#react-router-v2/3",
       "requires": {

--- a/amp/TEMPLATE/reamp/package.json
+++ b/amp/TEMPLATE/reamp/package.json
@@ -23,7 +23,7 @@
   "author": "Alexei Savca",
   "license": "inherit",
   "devDependencies": {
-    "amp-ui": "github:devgateway/amp-ui#fix/AMP-31133/Indicator-values-display-fixes",
+    "amp-ui": "git+https://github.com/devgateway/amp-ui.git#fix/AMP-31133/Indicator-values-display-fixes",
     "babel-core": "^6.26.3",
     "babel-jest": "^6.0.1",
     "babel-loader": "^6.3.2",

--- a/amp/TEMPLATE/reampv2/package-lock.json
+++ b/amp/TEMPLATE/reampv2/package-lock.json
@@ -2268,14 +2268,14 @@
     },
     "node_modules/@devgateway/amp-boilerplate": {
       "version": "0.1.3",
-      "resolved": "git+ssh://git@github.com/devgateway/amp-boilerplate.git#9f5127d3f53a16deb8f4f683a96ad45119646684",
+      "resolved": "git+https://github.com/devgateway/amp-boilerplate.git#9f5127d3f53a16deb8f4f683a96ad45119646684",
       "dependencies": {
         "amp-translate": "^0.0.1"
       }
     },
     "node_modules/@devgateway/amp-filter": {
       "version": "0.2.2",
-      "resolved": "git+ssh://git@github.com/devgateway/amp-filter.git#66495a9cb30768433add424d842662dadf51e17f",
+      "resolved": "git+https://github.com/devgateway/amp-filter.git#66495a9cb30768433add424d842662dadf51e17f",
       "license": "none",
       "dependencies": {
         "amp-translate": "^0.0.1"
@@ -2283,10 +2283,10 @@
     },
     "node_modules/@devgateway/amp-settings": {
       "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/devgateway/amp-settings.git#9f6e9ce846a64d25e412cd45e45c5deed2f56432",
+      "resolved": "git+https://github.com/devgateway/amp-settings.git#9f6e9ce846a64d25e412cd45e45c5deed2f56432",
       "license": "ISC",
       "dependencies": {
-        "amp-translate": "github:devgateway/amp-translate"
+        "amp-translate": "git+https://github.com/devgateway/amp-translate.git"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -8601,7 +8601,7 @@
     },
     "node_modules/amp-translate": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/devgateway/amp-translate.git#829eff1e75d978d1db4494f9a89b64aa1c420365",
+      "resolved": "git+https://github.com/devgateway/amp-translate.git#829eff1e75d978d1db4494f9a89b64aa1c420365",
       "dependencies": {
         "backbone": "1.1.2",
         "jquery": "2.1.1",
@@ -35043,7 +35043,7 @@
       "name": "ampoffiline",
       "version": "1.0.0",
       "dependencies": {
-        "@devgateway/amp-boilerplate": "github:devgateway/amp-boilerplate",
+        "@devgateway/amp-boilerplate": "git+https://github.com/devgateway/amp-boilerplate.git",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -35205,7 +35205,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-        "@devgateway/amp-boilerplate": "github:devgateway/amp-boilerplate",
+        "@devgateway/amp-boilerplate": "git+https://github.com/devgateway/amp-boilerplate.git",
         "@reduxjs/toolkit": "^1.9.5",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
@@ -35416,9 +35416,9 @@
       "name": "reampv2",
       "version": "1.0.1",
       "dependencies": {
-        "@devgateway/amp-boilerplate": "github:devgateway/amp-boilerplate",
-        "@devgateway/amp-filter": "github:devgateway/amp-filter",
-        "@devgateway/amp-settings": "github:devgateway/amp-settings",
+        "@devgateway/amp-boilerplate": "git+https://github.com/devgateway/amp-boilerplate.git",
+        "@devgateway/amp-filter": "git+https://github.com/devgateway/amp-filter.git",
+        "@devgateway/amp-settings": "git+https://github.com/devgateway/amp-settings.git",
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
         "@fortawesome/react-fontawesome": "^0.1.11",
@@ -36979,7 +36979,7 @@
     "packages/user-manager": {
       "version": "1.0.0",
       "dependencies": {
-        "@devgateway/amp-boilerplate": "github:devgateway/amp-boilerplate",
+        "@devgateway/amp-boilerplate": "git+https://github.com/devgateway/amp-boilerplate.git",
         "@reduxjs/toolkit": "^1.9.5",
         "@testing-library/jest-dom": "^6.1.2",
         "@testing-library/react": "^14.0.0",

--- a/amp/TEMPLATE/reampv2/packages/ampoffline/package.json
+++ b/amp/TEMPLATE/reampv2/packages/ampoffline/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "proxy": "http://localhost:8080",
   "dependencies": {
-    "@devgateway/amp-boilerplate": "github:devgateway/amp-boilerplate",
+    "@devgateway/amp-boilerplate": "git+https://github.com/devgateway/amp-boilerplate.git",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/amp/TEMPLATE/reampv2/packages/container/package.json
+++ b/amp/TEMPLATE/reampv2/packages/container/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-    "@devgateway/amp-boilerplate": "github:devgateway/amp-boilerplate",
+    "@devgateway/amp-boilerplate": "git+https://github.com/devgateway/amp-boilerplate.git",
     "@reduxjs/toolkit": "^1.9.5",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",

--- a/amp/TEMPLATE/reampv2/packages/reampv2-app/package.json
+++ b/amp/TEMPLATE/reampv2/packages/reampv2-app/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "proxy": "http://localhost:8080",
   "dependencies": {
-    "@devgateway/amp-boilerplate": "github:devgateway/amp-boilerplate",
-    "@devgateway/amp-filter": "github:devgateway/amp-filter",
-    "@devgateway/amp-settings": "github:devgateway/amp-settings",
+    "@devgateway/amp-boilerplate": "git+https://github.com/devgateway/amp-boilerplate.git",
+    "@devgateway/amp-filter": "git+https://github.com/devgateway/amp-filter.git",
+    "@devgateway/amp-settings": "git+https://github.com/devgateway/amp-settings.git",
     "@fortawesome/fontawesome-svg-core": "^1.2.30",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",

--- a/amp/TEMPLATE/reampv2/packages/user-manager/package.json
+++ b/amp/TEMPLATE/reampv2/packages/user-manager/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@devgateway/amp-boilerplate": "github:devgateway/amp-boilerplate",
+    "@devgateway/amp-boilerplate": "git+https://github.com/devgateway/amp-boilerplate.git",
     "@reduxjs/toolkit": "^1.9.5",
     "@testing-library/jest-dom": "^6.1.2",
     "@testing-library/react": "^14.0.0",

--- a/amp/src/main/java/org/digijava/kernel/viewmanager/reposimpl/TemplateViewConfigImpl.java
+++ b/amp/src/main/java/org/digijava/kernel/viewmanager/reposimpl/TemplateViewConfigImpl.java
@@ -22,24 +22,6 @@
 
 package org.digijava.kernel.viewmanager.reposimpl;
 
-/*
-*   DefaultViewConfigImpl.java
-*   @Author Mikheil Kapanadze mikheil@digijava.org
-*   Created: Apr 13, 2004
-*   CVS-ID: $Id: TemplateViewConfigImpl.java,v 1.1 2008-07-16 09:19:38 ktha Exp $
-*
-*   This file is part of DiGi project (www.digijava.org).
-*   DiGi is a multi-site portal system written in Java/J2EE.
-*
-*   Confidential and Proprietary, Subject to the Non-Disclosure
-*   Agreement, Version 2.0, between the Development Gateway
-*   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
-*   Gateway Foundation, Inc.
-*
-*   Unauthorized Disclosure Prohibited.
-*
-*************************************************************************/
-
 import org.digijava.kernel.viewmanager.ViewConfigException;
 
 import javax.servlet.ServletContext;

--- a/amp/src/main/java/org/digijava/kernel/viewmanager/reposimpl/ViewConfigImpl.java
+++ b/amp/src/main/java/org/digijava/kernel/viewmanager/reposimpl/ViewConfigImpl.java
@@ -22,24 +22,6 @@
 
 package org.digijava.kernel.viewmanager.reposimpl;
 
-/*
-*   DefaultViewConfigImpl.java
-*   @Author Mikheil Kapanadze mikheil@digijava.org
-*   Created: Apr 08, 2004
-*   CVS-ID: $Id: ViewConfigImpl.java,v 1.1 2008-07-16 09:19:38 ktha Exp $
-*
-*   This file is part of DiGi project (www.digijava.org).
-*   DiGi is a multi-site portal system written in Java/J2EE.
-*
-*   Confidential and Proprietary, Subject to the Non-Disclosure
-*   Agreement, Version 2.0, between the Development Gateway
-*   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
-*   Gateway Foundation, Inc.
-*
-*   Unauthorized Disclosure Prohibited.
-*
-*************************************************************************/
-
 import org.apache.log4j.Logger;
 import org.digijava.kernel.request.Site;
 import org.digijava.kernel.siteconfig.*;

--- a/amp/src/main/java/org/digijava/module/common/action/PaginationAction.java
+++ b/amp/src/main/java/org/digijava/module/common/action/PaginationAction.java
@@ -1,20 +1,3 @@
-/*
- *   PaginationAction.java
- *   @Author Lasha Dolidze lasha@digijava.org
- *   Created: Nov 17, 2003
-     *   CVS-ID: $Id$
- *
- *   This file is part of DiGi project (www.digijava.org).
- *   DiGi is a multi-site portal system written in Java/J2EE.
- *
- *   Confidential and Proprietary, Subject to the Non-Disclosure
- *   Agreement, Version 1.0, between the Development Gateway
- *   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
- *   Gateway Foundation, Inc.
- *
- *   Unauthorized Disclosure Prohibited.
- *
- *************************************************************************/
 package org.digijava.module.common.action;
 
 import org.apache.log4j.Logger;

--- a/amp/src/main/java/org/digijava/module/common/action/PaginationForm.java
+++ b/amp/src/main/java/org/digijava/module/common/action/PaginationForm.java
@@ -1,20 +1,3 @@
-/*
- *   PaginationForm.java
- *   @Author Lasha Dolidze lasha@digijava.org
- *   Created: Nov 17, 2003
- *   CVS-ID: $Id$
- *
- *   This file is part of DiGi project (www.digijava.org).
- *   DiGi is a multi-site portal system written in Java/J2EE.
- *
- *   Confidential and Proprietary, Subject to the Non-Disclosure
- *   Agreement, Version 1.0, between the Development Gateway
- *   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
- *   Gateway Foundation, Inc.
- *
- *   Unauthorized Disclosure Prohibited.
- *
- *************************************************************************/
 package org.digijava.module.common.action;
 
 import org.apache.struts.action.ActionErrors;

--- a/amp/src/main/java/org/digijava/module/common/dbentity/ItemStatus.java
+++ b/amp/src/main/java/org/digijava/module/common/dbentity/ItemStatus.java
@@ -1,21 +1,3 @@
-/*
-*   ItemStatus.java
-*   @Author Lasha Dolidze lasha@digijava.org
-*   Created:
-*   CVS-ID: $Id$
-*
-*   This file is part of DiGi project (www.digijava.org).
-*   DiGi is a multi-site portal system written in Java/J2EE.
-*
-*   Confidential and Proprietary, Subject to the Non-Disclosure
-*   Agreement, Version 1.0, between the Development Gateway
-*   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
-*   Gateway Foundation, Inc.
-*
-*   Unauthorized Disclosure Prohibited.
-*
-*************************************************************************/
-
 package org.digijava.module.common.dbentity;
 
 /**

--- a/amp/src/main/java/org/digijava/module/common/dbentity/ModuleTeaser.java
+++ b/amp/src/main/java/org/digijava/module/common/dbentity/ModuleTeaser.java
@@ -1,21 +1,3 @@
-/*
-*   ModuleTeaser.java
-*   @Author Lasha Dolidze lasha@digijava.org
-*   Created:
-*   CVS-ID: $Id$
-*
-*   This file is part of DiGi project (www.digijava.org).
-*   DiGi is a multi-site portal system written in Java/J2EE.
-*
-*   Confidential and Proprietary, Subject to the Non-Disclosure
-*   Agreement, Version 1.0, between the Development Gateway
-*   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
-*   Gateway Foundation, Inc.
-*
-*   Unauthorized Disclosure Prohibited.
-*
-*************************************************************************/
-
 package org.digijava.module.common.dbentity;
 
 /**

--- a/amp/src/main/java/org/digijava/module/common/exception/BBCodeException.java
+++ b/amp/src/main/java/org/digijava/module/common/exception/BBCodeException.java
@@ -1,21 +1,3 @@
-/*
- *   BBCodeException.java
- *   @Author Maka Kharalashvili maka@digijava.org
- *   Created: Oct 20, 2003
- *   CVS-ID: $Id$
- *
- *   This file is part of DiGi project (www.digijava.org).
- *   DiGi is a multi-site portal system written in Java/J2EE.
- *
- *   Confidential and Proprietary, Subject to the Non-Disclosure
- *   Agreement, Version 1.0, between the Development Gateway
- *   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
- *   Gateway Foundation, Inc.
- *
- *   Unauthorized Disclosure Prohibited.
- *
- *************************************************************************/
-
 package org.digijava.module.common.exception;
 import org.digijava.kernel.exception.DgException;
 

--- a/amp/src/main/java/org/digijava/module/common/util/BBCodeParser.java
+++ b/amp/src/main/java/org/digijava/module/common/util/BBCodeParser.java
@@ -1,21 +1,3 @@
-/*
- *   BBCodeParser.java
- *   @Author Maka Kharalashvili maka@digijava.org
- *   Created: Oct 20, 2003
- *   CVS-ID: $Id$
- *
- *   This file is part of DiGi project (www.digijava.org).
- *   DiGi is a multi-site portal system written in Java/J2EE.
- *
- *   Confidential and Proprietary, Subject to the Non-Disclosure
- *   Agreement, Version 1.0, between the Development Gateway
- *   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
- *   Gateway Foundation, Inc.
- *
- *   Unauthorized Disclosure Prohibited.
- *
- *************************************************************************/
-
 package org.digijava.module.common.util;
 
 import org.apache.log4j.Logger;

--- a/amp/src/main/java/org/digijava/module/common/util/DateTimeUtil.java
+++ b/amp/src/main/java/org/digijava/module/common/util/DateTimeUtil.java
@@ -1,20 +1,3 @@
-/*
- *   DateTimeUtil.java
- *   @Author Lasha Dolidze lasha@digijava.org
- *   Created: Oct 20, 2003
- *   CVS-ID: $Id$
- *
- *   This file is part of DiGi project (www.digijava.org).
- *   DiGi is a multi-site portal system written in Java/J2EE.
- *
- *   Confidential and Proprietary, Subject to the Non-Disclosure
- *   Agreement, Version 1.0, between the Development Gateway
- *   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
- *   Gateway Foundation, Inc.
- *
- *   Unauthorized Disclosure Prohibited.
- *
- *************************************************************************/
 package org.digijava.module.common.util;
 
 import org.digijava.kernel.ampapi.endpoints.common.EPConstants;

--- a/amp/src/main/java/org/digijava/module/common/util/ModuleEmailManager.java
+++ b/amp/src/main/java/org/digijava/module/common/util/ModuleEmailManager.java
@@ -1,21 +1,3 @@
-/*
- *   ModuleEmailManager.java
- *   @Author Maka Kharalashvili maka@digijava.org
- *   Created: Apr 21, 2004
- *  CVS-ID: $Id$
- *
- *   This file is part of DiGi project (www.digijava.org).
- *   DiGi is a multi-site portal system written in Java/J2EE.
- *
- *   Confidential and Proprietary, Subject to the Non-Disclosure
- *   Agreement, Version 1.0, between the Development Gateway
- *   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
- *   Gateway Foundation, Inc.
- *
- *   Unauthorized Disclosure Prohibited.
- *
- *************************************************************************/
-
 package org.digijava.module.common.util;
 
 import org.apache.log4j.Logger;

--- a/amp/src/main/java/org/digijava/module/common/util/ModuleUtil.java
+++ b/amp/src/main/java/org/digijava/module/common/util/ModuleUtil.java
@@ -1,20 +1,3 @@
-/*
- *   ModuleUtil.java
- *   @Author Lasha Dolidze lasha@digijava.org
- *   Created: Oct 20, 2003
- *   CVS-ID: $Id$
- *
- *   This file is part of DiGi project (www.digijava.org).
- *   DiGi is a multi-site portal system written in Java/J2EE.
- *
- *   Confidential and Proprietary, Subject to the Non-Disclosure
- *   Agreement, Version 1.0, between the Development Gateway
- *   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
- *   Gateway Foundation, Inc.
- *
- *   Unauthorized Disclosure Prohibited.
- *
- *************************************************************************/
 package org.digijava.module.common.util;
 
 import java.util.StringTokenizer;

--- a/amp/src/main/java/org/digijava/module/editor/taglib/EditTag.java
+++ b/amp/src/main/java/org/digijava/module/editor/taglib/EditTag.java
@@ -1,21 +1,3 @@
-/*
- *   EditTag.java
- *   @Author Maka Kharalashvili maka@digijava.org
- *   Created: Dec 17, 2003
- *   CVS-ID: $Id$
- *
- *   This file is part of DiGi project (www.digijava.org).
- *   DiGi is a multi-site portal system written in Java/J2EE.
- *
- *   Confidential and Proprietary, Subject to the Non-Disclosure
- *   Agreement, Version 1.0, between the Development Gateway
- *   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
- *   Gateway Foundation, Inc.
- *
- *   Unauthorized Disclosure Prohibited.
- *
- *************************************************************************/
-
 package org.digijava.module.editor.taglib;
 
 import org.apache.log4j.Logger;

--- a/amp/src/main/java/org/digijava/module/um/form/AddUserForm.java
+++ b/amp/src/main/java/org/digijava/module/um/form/AddUserForm.java
@@ -1,24 +1,5 @@
 package org.digijava.module.um.form;
 
-/*
- *   UserRegisterForm.java
- *   @Author Lasha Dolidze lasha@digijava.org
- *   Created:
- *   CVS-ID: $Id: AddUserForm.java,v 1.2 2008-11-26 01:25:52 msotero Exp $
- *
- *   This file is part of DiGi project (www.digijava.org).
- *   DiGi is a multi-site portal system written in Java/J2EE.
- *
- *   Confidential and Proprietary, Subject to the Non-Disclosure
- *   Agreement, Version 1.0, between the Development Gateway
- *   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
- *   Gateway Foundation, Inc.
- *
- *   Unauthorized Disclosure Prohibited.
- *
- *************************************************************************/
-
-
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionMapping;
 import org.apache.struts.validator.ValidatorForm;

--- a/amp/src/main/java/org/digijava/module/um/form/UserRegisterForm.java
+++ b/amp/src/main/java/org/digijava/module/um/form/UserRegisterForm.java
@@ -1,21 +1,3 @@
-/*
- *   UserRegisterForm.java
- *   @Author Lasha Dolidze lasha@digijava.org
- *   Created:
- *   CVS-ID: $Id$
- *
- *   This file is part of DiGi project (www.digijava.org).
- *   DiGi is a multi-site portal system written in Java/J2EE.
- *
- *   Confidential and Proprietary, Subject to the Non-Disclosure
- *   Agreement, Version 1.0, between the Development Gateway
- *   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
- *   Gateway Foundation, Inc.
- *
- *   Unauthorized Disclosure Prohibited.
- *
- *************************************************************************/
-
 package org.digijava.module.um.form;
 
 import org.apache.struts.action.ActionErrors;

--- a/amp/src/main/java/org/digijava/module/um/util/DbUtil.java
+++ b/amp/src/main/java/org/digijava/module/um/util/DbUtil.java
@@ -1,20 +1,3 @@
-/*
- *   DbUtil.java
- *   @Author Lasha Dolidze lasha@digijava.org
- *   Created:
- *   CVS-ID: $Id$
- *
- *   This file is part of DiGi project (www.digijava.org).
- *   DiGi is a multi-site portal system written in Java/J2EE.
- *
- *   Confidential and Proprietary, Subject to the Non-Disclosure
- *   Agreement, Version 1.0, between the Development Gateway
- *   Foundation, Inc and the Recipient -- Copyright 2001-2004 Development
- *   Gateway Foundation, Inc.
- *
- *   Unauthorized Disclosure Prohibited.
- *
- *************************************************************************/
 package org.digijava.module.um.util;
 
 import org.apache.log4j.Logger;


### PR DESCRIPTION
## Summary
Enables external contributors to clone and build the project without SSH keys or privileged access (AMP-31192).

## Changes
- **`.gitmodules`** — converted the three submodule URLs (amp-boilerplate, amp-translate, amp-filter) from SSH (`git@github.com:`) to HTTPS; the repos are public now.
- **Proprietary license headers** — removed the legacy "Confidential and Proprietary / Unauthorized Disclosure Prohibited" comment blocks from 15 Java files, which conflict with the repo's GPLv3 license. GPL headers preserved where present; delete-only, no replacements.
- **npm git dependencies** — replaced `github:` shorthand and dead `git://` specifiers with explicit `git+https://` URLs in 6 package.json files, and rewrote `git+ssh://` resolved URLs in 4 package-lock.json files (reampv2, reamp, amp-settings, dashboard/dev). Pinned commit SHAs are unchanged — protocol swap only, zero version drift. Lockfile-recorded specs were updated in sync so `npm ci` accepts them.

## Verification
- All 8 git-dependency repos confirmed publicly reachable over HTTPS (`git ls-remote`)
- `npm ci --dry-run` passes for reampv2 (3122 packages) and amp-settings (737 packages)
- All touched JSON files parse; repo-wide grep finds no remaining SSH/git-protocol install specs
- Note: `npm ci --dry-run` for reamp and dashboard/dev fails locally **identically on pristine develop** (legacy webpack-1 peer conflict; Linux-generated lockfiles under npm 11) — pre-existing, unrelated to this change

## Notes for reviewers
- Existing local clones need `git submodule sync` after merge
- Suggested final check: fresh `git clone --recurse-submodules` + Maven build as an outside user
- Follow-ups in other repos: transitive git deps are declared in the amp-ui / amp-settings GitHub repos' package.json files, and the submodule repos' own lockfiles may need the same treatment
